### PR TITLE
fix dataset names in scripts

### DIFF
--- a/src/my_awesome_project/azureml/aml_clean_data.py
+++ b/src/my_awesome_project/azureml/aml_clean_data.py
@@ -4,9 +4,9 @@ from my_awesome_project.data.clean_input_data import clean
 
 if __name__ == "__main__":
     run = Run.get_context()
-    raw_df = run.input_datasets["my_raw_dataset"].to_pandas_dataframe()
+    raw_df = run.input_datasets["my_raw_data"].to_pandas_dataframe()
 
     clean_df = clean(raw_df)
-    mounted_output_dir = run.output_datasets["my_clean_dataset"]
+    mounted_output_dir = run.output_datasets["my_clean_data"]
     os.makedirs(os.path.dirname(mounted_output_dir), exist_ok=True)
     clean_df.to_parquet(mounted_output_dir)

--- a/src/my_awesome_project/azureml/aml_train_model.py
+++ b/src/my_awesome_project/azureml/aml_train_model.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     ap.add_argument("--epochs", default=10)
     args = ap.parse_args()
 
-    clean_df = run.input_datasets["my_clean_dataset"].to_pandas_dataframe()
+    clean_df = run.input_datasets["my_clean_data"].to_pandas_dataframe()
     trained_model = train_model(data=clean_df, epochs=args.epochs)
     trained_model.save("./outputs/model")  # /outputs is important
     run.register_model(name="my_model", path="outputs/model")


### PR DESCRIPTION
This is a really useful repo.

I was going through the code and found that the dataset names in the Python scripts - [`aml_clean_data`](https://github.com/brunocous/azureml-pipeline-demo/blob/main/src/my_awesome_project/azureml/aml_clean_data.py) ([1](https://github.com/brunocous/azureml-pipeline-demo/blob/4e3f85a4551de86d1c3d91abec128c5be7267204/src/my_awesome_project/azureml/aml_clean_data.py#L7) and [2](https://github.com/brunocous/azureml-pipeline-demo/blob/4e3f85a4551de86d1c3d91abec128c5be7267204/src/my_awesome_project/azureml/aml_clean_data.py#L10)) and [`aml_train_data`](https://github.com/brunocous/azureml-pipeline-demo/blob/4e3f85a4551de86d1c3d91abec128c5be7267204/src/my_awesome_project/azureml/aml_train_model.py#L11) - were incorrect compared to the names that were set in the [pipeline creation script](https://github.com/brunocous/azureml-pipeline-demo/blob/4e3f85a4551de86d1c3d91abec128c5be7267204/src/my_awesome_project/azureml/create_and_trigger_pipeline.py#L29-L40).

I have made the changes here to fix these minor typos.